### PR TITLE
Install MathML and SVG headers

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -258,8 +258,19 @@ lasem_dom_types = gnome.mkenums_simple(
 	install_header : true
 )
 
-lasem_mathml_types = gnome.mkenums_simple('lsmmathmlenumtypes', sources : lasem_mathml_headers)
-lasem_svg_types = gnome.mkenums_simple('lsmsvgenumtypes', sources : lasem_svg_headers)
+lasem_mathml_types = gnome.mkenums_simple(
+	'lsmmathmlenumtypes',
+	sources : lasem_mathml_headers,
+	install_dir : join_paths(get_option('includedir'), lasem_header_install_dir, 'mathml'),
+	install_header : true
+)
+
+lasem_svg_types = gnome.mkenums_simple(
+	'lsmsvgenumtypes',
+	sources : lasem_svg_headers,
+	install_dir : join_paths(get_option('includedir'), lasem_header_install_dir, 'svg'),
+	install_header : true
+)
 
 # combine sources
 sources = [
@@ -280,6 +291,8 @@ sources = [
 
 # install headers
 install_headers(lasem_dom_headers, subdir : lasem_header_install_dir)
+install_headers(lasem_mathml_headers, subdir : lasem_header_install_dir / 'mathml')
+install_headers(lasem_svg_headers, subdir : lasem_header_install_dir / 'svg')
 
 # lasem shared library
 liblasem = shared_library(


### PR DESCRIPTION
We want to interact with the MathML module in order to implement equation introspection. This requires the headers to be available to consuming libraries.