### PR TITLE
build: Add flatpak manifest for demo

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Release 0.7.0
 =============
   * build: port build system to meson
+  * build: add flatpak manifest
   * demo: add a gtk4 mathml viewer demo
   * increase api version to 0.7 to avoid conflicts with lasem packages
 

--- a/com.mattjakeman.LasemDemo.json
+++ b/com.mattjakeman.LasemDemo.json
@@ -1,0 +1,41 @@
+{
+    "app-id" : "com.mattjakeman.LasemDemo",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "41",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "lsm-demo",
+    "finish-args" : [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "lasem",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "config-opts" : [
+            	"-Ddemo=enabled"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "path" : "./"
+                }
+            ]
+        }
+    ]
+}

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -174,7 +174,7 @@ main (int    argc,
     GtkApplication *app;
     int status;
 
-    app = gtk_application_new ("com.mattjakeman.lsm-demo", G_APPLICATION_FLAGS_NONE);
+    app = gtk_application_new ("com.mattjakeman.LasemDemo", G_APPLICATION_FLAGS_NONE);
     g_signal_connect (app, "activate", G_CALLBACK (activate), NULL);
     status = g_application_run (G_APPLICATION (app), argc, argv);
     g_object_unref (app);


### PR DESCRIPTION
Make it easy to get started with Lasem by adding a flatpak manifest.