### PR TITLE
Cursor Experiment

### DIFF
--- a/demo/demo-resources.gresource.xml
+++ b/demo/demo-resources.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+    <gresource prefix="/com/mattjakeman/lsm-demo">
+        <file>demo.ui</file>
+    </gresource>
+</gresources>

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -124,6 +124,9 @@ lasem_view_draw (GtkDrawingArea *drawing_area,
                          window->pick->y,
                          window->pick->bbox.width,
                          -window->pick->bbox.height);
+        cairo_fill (cr);
+
+        cairo_set_source_rgba (cr, 153/255.0, 193/255.0, 241/255.0, 0.2);
         cairo_rectangle (cr,
                          window->pick->x,
                          window->pick->y,
@@ -149,13 +152,20 @@ cb_motion (GtkEventControllerMotion *controller,
     if (self->pick != NULL)
     {
         const char *fmt;
-        fmt = g_strdup_printf ("Picked '%s' (<%s>) at:\nX: %.2lf\nY: %.2lf",
+        fmt = g_strdup_printf ("Picked '%s' (<%s>) at:\nX: %.2lf\nY: %.2lf\nElement X: %.2lf\nElement Y: %.2lf\nElement Width: %.2lf\nElement Height: %.2lf\nElement Depth: %.2lf\n",
                                g_type_name_from_instance ((GTypeInstance *)self->pick),
                                lsm_dom_node_get_node_name (LSM_DOM_NODE (self->pick)),
-                               x, y);
+                               x, y, // TODO: These are GTK positions, not equation coords
+                               self->pick->x,
+                               self->pick->y,
+                               self->pick->bbox.width,
+                               self->pick->bbox.height,
+                               self->pick->bbox.depth);
 
         gtk_label_set_label (self->status_label, fmt);
     }
+    else
+        gtk_label_set_label (self->status_label, NULL);
 
     GtkWidget *lasem_view = gtk_event_controller_get_widget (GTK_EVENT_CONTROLLER (controller));
     gtk_widget_queue_draw (lasem_view);

--- a/demo/demo.ui
+++ b/demo/demo.ui
@@ -29,6 +29,9 @@
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkDrawingArea" id="lasem_view">
+                <property name="can-focus">true</property>
+                <property name="focusable">true</property>
+                <property name="focus-on-click">true</property>
                 <property name="vexpand">true</property>
               </object>
             </child>

--- a/demo/demo.ui
+++ b/demo/demo.ui
@@ -1,0 +1,46 @@
+<interface>
+  <template class="DemoWindow" parent="GtkApplicationWindow">
+    <property name="title">Lasem Demo</property>
+    <property name="default-width">800</property>
+    <property name="default-height">600</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <child type="end">
+          <object class="GtkButton" id="render_btn">
+            <property name="label">Render</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">horizontal</property>
+        <property name="homogeneous">1</property>
+        <child>
+          <object class="GtkScrolledWindow">
+            <child>
+              <object class="GtkTextView" id="text_view">
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkDrawingArea" id="lasem_view">
+                <property name="vexpand">true</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="status_label">
+                <property name="wrap">true</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/demo/meson.build
+++ b/demo/meson.build
@@ -6,9 +6,15 @@ demo_deps = [
 	dependency('gtk4')
 ]
 
+demo_resources = gnome.compile_resources(
+    'demo-resources', 'demo-resources.gresource.xml',
+    c_name: 'demo_resources'
+)
+
 lasemdemo = executable(
     'lsm-demo',
     'demo.c',
+    demo_resources,
     dependencies : demo_deps,
     install : true
 )

--- a/src/lsmdomcursor.c
+++ b/src/lsmdomcursor.c
@@ -1,0 +1,195 @@
+/* Lasem
+ *
+ * Copyright © 2021 Matthew Jakeman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1335, USA.
+ *
+ * Author:
+ * 	Matthew Jakeman <mjakeman26@outlook.co.nz>
+ */
+
+#include "lsmdomcursor.h"
+
+struct _LsmDomCursor
+{
+    GObject parent_instance;
+
+    LsmDomNode *current;
+
+    // Currently 0=start, 1=end
+    int position;
+};
+
+G_DEFINE_FINAL_TYPE (LsmDomCursor, lsm_dom_cursor, G_TYPE_OBJECT)
+
+enum {
+    PROP_0,
+    PROP_CURRENT,
+    N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS];
+
+LsmDomCursor *
+lsm_dom_cursor_new (void)
+{
+    return g_object_new (LSM_TYPE_DOM_CURSOR, NULL);
+}
+
+static void
+lsm_dom_cursor_finalize (GObject *object)
+{
+    LsmDomCursor *self = (LsmDomCursor *)object;
+
+    G_OBJECT_CLASS (lsm_dom_cursor_parent_class)->finalize (object);
+}
+
+static void
+lsm_dom_cursor_get_property (GObject    *object,
+                             guint       prop_id,
+                             GValue     *value,
+                             GParamSpec *pspec)
+{
+    LsmDomCursor *self = LSM_DOM_CURSOR (object);
+
+    switch (prop_id)
+    {
+    case PROP_CURRENT:
+        g_value_set_object (value, self->current);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+lsm_dom_cursor_set_property (GObject      *object,
+                             guint         prop_id,
+                             const GValue *value,
+                             GParamSpec   *pspec)
+{
+    LsmDomCursor *self = LSM_DOM_CURSOR (object);
+
+    switch (prop_id)
+    {
+    case PROP_CURRENT:
+        self->current = g_value_get_object (value);
+        self->position = 0;
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+void
+lsm_dom_cursor_move (LsmDomCursor *self, LsmDirection direction)
+{
+    LsmDomNode *move_to = NULL;
+    int new_pos = self->position;
+
+    if (!self->current)
+        return;
+
+    if (direction == LSM_DIRECTION_LEFT)
+    {
+        // TODO: First try move within the current element
+
+        if (self->position != 0)
+        {
+            // At end, try to move to a child element
+            move_to = lsm_dom_node_get_last_child (self->current);
+            new_pos = 1;
+
+            if (move_to)
+                goto move;
+        }
+
+        // Failing that, move to the previous sibling node
+        move_to = lsm_dom_node_get_previous_sibling (self->current);
+        new_pos = 1;
+
+        if (move_to)
+            goto move;
+
+        // Move to parent start
+        move_to = lsm_dom_node_get_parent_node (self->current);
+        new_pos = 0;
+
+        if (move_to)
+            goto move;
+    }
+    else if (direction == LSM_DIRECTION_RIGHT)
+    {
+        // Try move within the current element
+        // TODO HERE
+
+        if (self->position != 1)
+        {
+            // At start, try to move to a child element
+            move_to = lsm_dom_node_get_first_child (self->current);
+            new_pos = 0;
+
+            if (move_to)
+                goto move;
+        }
+
+        // Try move to next sibling
+        move_to = lsm_dom_node_get_next_sibling (self->current);
+        new_pos = 0;
+
+        if (move_to)
+            goto move;
+
+        // Failing that, move to parent end
+        move_to = lsm_dom_node_get_parent_node (self->current);
+        new_pos = 1;
+
+        if (move_to)
+            goto move;
+    }
+
+    return;
+
+move:
+    // TODO: Emit notify?
+    self->current = move_to;
+    self->position = new_pos;
+    g_print ("Moved to: %s (%d)\n", lsm_dom_node_get_node_name (self->current), self->position);
+}
+
+static void
+lsm_dom_cursor_class_init (LsmDomCursorClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->finalize = lsm_dom_cursor_finalize;
+    object_class->get_property = lsm_dom_cursor_get_property;
+    object_class->set_property = lsm_dom_cursor_set_property;
+
+    properties [PROP_CURRENT]
+        = g_param_spec_object ("current",
+                               "Current",
+                               "Currently selected element",
+                               LSM_TYPE_DOM_NODE,
+                               G_PARAM_READWRITE);
+
+    g_object_class_install_properties (object_class, N_PROPS, properties);
+}
+
+static void
+lsm_dom_cursor_init (LsmDomCursor *self)
+{
+}

--- a/src/lsmdomcursor.h
+++ b/src/lsmdomcursor.h
@@ -1,0 +1,47 @@
+/* Lasem
+ *
+ * Copyright © 2021 Matthew Jakeman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1335, USA.
+ *
+ * Author:
+ * 	Matthew Jakeman <mjakeman26@outlook.co.nz>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include <lsmdom.h>
+
+G_BEGIN_DECLS
+
+#define LSM_TYPE_DOM_CURSOR (lsm_dom_cursor_get_type())
+
+G_DECLARE_FINAL_TYPE (LsmDomCursor, lsm_dom_cursor, LSM, DOM_CURSOR, GObject)
+
+typedef enum
+{
+    LSM_DIRECTION_UP,
+    LSM_DIRECTION_DOWN,
+    LSM_DIRECTION_LEFT,
+    LSM_DIRECTION_RIGHT,
+} LsmDirection;
+
+LsmDomCursor *lsm_dom_cursor_new (void);
+
+void lsm_dom_cursor_move (LsmDomCursor *self, LsmDirection direction);
+
+G_END_DECLS

--- a/src/lsmmathmlview.h
+++ b/src/lsmmathmlview.h
@@ -89,6 +89,10 @@ GType lsm_mathml_view_get_type (void);
 
 LsmMathmlView *		lsm_mathml_view_new 		(LsmMathmlDocument *document);
 
+LsmMathmlElement *  lsm_mathml_view_pick        (LsmDomView *dom_view,
+                                                 double      x,
+                                                 double      y);
+
 /* Internal API */
 
 double 		lsm_mathml_view_measure_axis_offset	(LsmMathmlView *view, double math_size);

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,7 +21,8 @@ lasem_dom_sources = [
 	'lsmdomtext.c',
 	'lsmdomview.c',
 	'lsmdomparser.c',
-	'lsmdomimplementation.c'
+	'lsmdomimplementation.c',
+    'lsmdomcursor.c'
 ]
 
 lasem_mathml_sources = [


### PR DESCRIPTION
An experiment with implementing a cursor to navigate the MathML document. This implementation uses a DFS-like approach where pressing 'Left' or 'Right' navigates first to child elements, then to sibling elements, then to the parent element, exploring each subtree fully.

For many reasons, this is not an ideal way to implement a cursor. However, it may be worth keeping around as an alternative/fallback.

The object should probably be named `LsmDomNavigator` or similar in this case.