### PR TITLE
Explicitly include DOM module in introspection data

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -280,6 +280,7 @@ sources = [
   lasem_svg_sources,
 
   # Headers
+  lasem_dom_headers,
   lasem_mathml_headers,
   lasem_svg_headers,
 ]


### PR DESCRIPTION
It seems DOM structures were accidentally removed when including MathML and SVG sources - explicitly include them.