### PR TITLE
Fix duplicate entry in LINGUAS (it)

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -14,7 +14,6 @@ hr
 hu
 id
 it
-it
 lt
 lv
 nb


### PR DESCRIPTION
```
meson _build
```
was failing with
```
po/meson.build:2:5: ERROR: Tried to create target "lasem-0.7-it.mo", but a target of that name already exists.
```
The cause was a duplicate entry of `it` in `po/LINGUAS`.